### PR TITLE
Setup GH Actions for continuous integration of the notebooks

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,3 +1,0 @@
-name: bmlip-env
-dependencies:
-  - jupyter >= 1.0

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,0 +1,3 @@
+name: bmlip-env
+dependencies:
+  - jupyter >= 1.0

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
-      platform: [ubuntu-latest, ubuntu-18.04, macos-latest]
+        platform: [ubuntu-latest, ubuntu-18.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest]
+        platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -23,9 +23,17 @@ jobs:
     # Install Jupyter with Julia kernel
     - name: Setup Miniconda
       uses: goanpeca/setup-miniconda@v1.0.2
+      with:
+        miniconda-version: 'latest'
 
     - name: Setup Jupyter
       run: conda install -c conda-forge notebook
 
     - name: Setup IJulia
       run: julia -e 'using Pkg; Pkg.add("IJulia")'
+
+    # Run lesson notebooks
+    - name: Test notebook 00
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+    - name: Test notebook 01
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,9 +47,7 @@ jobs:
 
     # Add IJulia kernel to Jupyter
     - name: Install IJulia kernel
-      run: |
-        pwd
-        julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaLang/IJulia.jl.git")); using IJulia; installkernel("julia")'
+      run: julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaLang/IJulia.jl.git")); using IJulia; installkernel("julia")'
 
     # # Run lesson notebooks
     # - name: Test notebook 00

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         conda update conda
         conda create -n bmlip python=3.7 anaconda
-        source activate bmlip
+        conda activate bmlip
         conda list
         conda install -c anaconda jupyter
         conda install -c conda-forge notebook

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,10 +46,8 @@ jobs:
 
     # Add IJulia kernel to Jupyter
     - name: Install IJulia kernel
-      run: |
-        git clone https://github.com/JuliaLang/IJulia.jl.git IJulia
-        cd IJulia
-        julia -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.status(); using IJulia; installkernel("julia")'
+      shell: bash -l {0}
+      run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
 
     # # Run lesson notebooks
     # - name: Test notebook 00

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,13 +27,13 @@ jobs:
       with:
         miniconda-version: 'latest'
         python-version: 3.7
-    - shell: bash -l {0}
-      run: conda list
 
     # Install Jupyter
     - name: Setup Jupyter
       shell: bash -l {0}
-      run: conda install -c anaconda jupyter
+      run: |
+        conda install -c anaconda jupyter
+        conda list
 
     # Install Julia
     - name: Setup Julia environment
@@ -50,6 +50,28 @@ jobs:
     # Run lesson notebooks
     - name: Test notebook 00
       shell: bash -l {0}
-      run: |
-        cd lessons/notebooks
-        jupyter nbconvert --to notebook --inplace --execute 00-Course-Outline-and-Admin-Issues.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+
+    - name: Test notebook 01
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb
+
+    - name: Test notebook 02
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/02-Probability-Theory-Review.ipynb
+
+    - name: Test notebook 03
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+
+    - name: Test notebook 04
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+
+    - name: Test notebook 05
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+
+    - name: Test notebook 06
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/06-Regression.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     strategy:
       matrix:
@@ -29,11 +29,11 @@ jobs:
         python-version: 3.7
 
     # Install Python dependencies
-    - name: Setup Jupyter
+    - name: Install Python dependencies
       shell: bash -l {0}
       run: |
         conda install -c anaconda jupyter
-        conda install -c conda-forge matplotlib 
+        conda install -c conda-forge matplotlib
         conda list
 
     # Install Julia
@@ -45,7 +45,7 @@ jobs:
         show-versioninfo: true
 
     # Add IJulia kernel to Jupyter
-    - name: Setup IJulia
+    - name: Install IJulia kernel
       run: julia -e 'using Pkg; Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
@@ -76,3 +76,59 @@ jobs:
     - name: Test notebook 06
       shell: bash -l {0}
       run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
+
+    - name: Test notebook 07
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
+
+    - name: Test notebook 08
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
+
+    - name: Test notebook 09
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
+
+    - name: Test notebook 10
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
+
+    - name: Test notebook 11
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/11-Dynamic-Models.ipynb
+
+    - name: Test notebook 12
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
+
+    # - name: Test notebook PP-1-variational
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-1-variational.ipynb
+    #
+    # - name: Test notebook PP-1-sampling
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-1-sampling.ipynb
+    #
+    # - name: Test notebook PP-2-variational
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-2-variational.ipynb
+    #
+    # - name: Test notebook PP-2-sampling
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-2-sampling.ipynb
+    #
+    # - name: Test notebook PP-3-variational
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-3-variational.ipynb
+    #
+    # - name: Test notebook PP-3-sampling
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-3-sampling.ipynb
+    #
+    # - name: Test notebook PP-4-variational
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-4-variational.ipynb
+    #
+    # - name: Test notebook PP-4-sampling
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-4-sampling.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install -c anaconda jupyter
-        conda install -c conda-giforge matplotlib
+        conda install -c conda-forge matplotlib
         conda install -c anaconda graphviz
         conda install pip
         pip install graphviz

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
+        # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
+      platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,12 +32,21 @@ jobs:
       run: |
         conda install -c conda-forge jupyterlab
         conda install -c conda-forge notebook
+        conda update -n base -c defaults conda
         conda info
         conda list
 
     - name: Setup IJulia
       run: julia -e 'using Pkg; Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
 
+    # Clone repo
+    - name: Clone BMLIP repo
+      run: |
+        git clone https://github.com/bertdv/BMLIP.git
+        cd BMLIP
+
     # Run lesson notebooks
     - name: Test notebook 00
-      run: ls -a
+      run: |
+        ls -a
+        jupyter nbconvert --to notebook --inplace --execute "./lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         ref: master
 
+    # Install GraphViz
+    - name: Setup GraphViz
+      uses: kamiazya/setup-graphviz@v1
+
     # Setup Miniconda environment
     - name: Setup Miniconda
       uses: goanpeca/setup-miniconda@v1.0.2
@@ -34,16 +38,6 @@ jobs:
         conda install -c anaconda jupyter
         conda install -c conda-forge matplotlib
         conda install -c anaconda graphviz
-        conda install pip
-        pip install graphviz
-
-    # Install GraphViz
-    - name: Setup GraphViz
-      uses: kamiazya/setup-graphviz@v1
-
-    - name: test dot
-      shell: bash -l {0}
-      run: dot -V
 
     # Install Julia
     - name: Setup Julia environment
@@ -59,49 +53,49 @@ jobs:
       run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
-    # - name: Test notebook 00
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
-    #
-    # - name: Test notebook 01
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
-    #
-    # - name: Test notebook 02
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
-    #
-    # - name: Test notebook 03
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
-    #
-    # - name: Test notebook 04
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
-    #
-    # - name: Test notebook 05
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
-    #
-    # - name: Test notebook 06
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
-    #
-    # - name: Test notebook 07
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
-    #
-    # - name: Test notebook 08
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
-    #
-    # - name: Test notebook 09
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
-    #
-    # - name: Test notebook 10
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
+    - name: Test notebook 00
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+
+    - name: Test notebook 01
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
+
+    - name: Test notebook 02
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
+
+    - name: Test notebook 03
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+
+    - name: Test notebook 04
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+
+    - name: Test notebook 05
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+
+    - name: Test notebook 06
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
+
+    - name: Test notebook 07
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
+
+    - name: Test notebook 08
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
+
+    - name: Test notebook 09
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
+
+    - name: Test notebook 10
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
 
     - name: Test notebook 11
       shell: bash -l {0}
@@ -110,35 +104,3 @@ jobs:
     - name: Test notebook 12
       shell: bash -l {0}
       run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
-
-    # - name: Test notebook PP-1-variational
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-1-variational.ipynb
-    #
-    # - name: Test notebook PP-1-sampling
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-1-sampling.ipynb
-    #
-    # - name: Test notebook PP-2-variational
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-2-variational.ipynb
-    #
-    # - name: Test notebook PP-2-sampling
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-2-sampling.ipynb
-    #
-    # - name: Test notebook PP-3-variational
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-3-variational.ipynb
-    #
-    # - name: Test notebook PP-3-sampling
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-3-sampling.ipynb
-    #
-    # - name: Test notebook PP-4-variational
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-4-variational.ipynb
-    #
-    # - name: Test notebook PP-4-sampling
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/probprog/Probabilistic-Programming-4-sampling.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,13 +27,17 @@ jobs:
       uses: goanpeca/setup-miniconda@v1.0.2
       with:
         miniconda-version: 'latest'
+      run: |
+        conda update conda
+        conda create -n bmlip python=3.7 anaconda
+        source activate bmlip
 
     - name: Setup Jupyter
       run: |
-        conda update -n base -c defaults conda
+        conda list
+        conda install -c anaconda jupyter
         conda install -c conda-forge notebook
         conda install -c conda-forge jupyterlab
-        conda info
         conda list
 
     - name: Setup IJulia

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         miniconda-version: 'latest'
         activate-environment: bmlip-env
-        environment-file: BMLIP/.github/workflows/environment.yml
+        environment-file: BMLIP/environment.yml
         python-version: 3.7
     - shell: bash -l {0}
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
-      platform: [ubuntu-latest]
+      platform: [ubuntu-latest, ubuntu-18.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         conda install -c anaconda jupyter
         conda install -c conda-forge matplotlib
+        conda install -c anaconda graphviz 
         conda list
 
     # Install Julia

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -50,28 +50,28 @@ jobs:
     # Run lesson notebooks
     - name: Test notebook 00
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
 
     - name: Test notebook 01
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
 
     - name: Test notebook 02
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/02-Probability-Theory-Review.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
 
     - name: Test notebook 03
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
 
     - name: Test notebook 04
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
 
     - name: Test notebook 05
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
 
     - name: Test notebook 06
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/06-Regression.ipynb
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,18 +21,19 @@ jobs:
       with:
         ref: master
 
-    # Install Miniconda environment
+    # Setup Miniconda environment
     - name: Setup Miniconda
       uses: goanpeca/setup-miniconda@v1.0.2
       with:
         miniconda-version: 'latest'
         python-version: 3.7
 
-    # Install Jupyter
+    # Install Python dependencies
     - name: Setup Jupyter
       shell: bash -l {0}
       run: |
         conda install -c anaconda jupyter
+        conda install -c conda-forge matplotlib 
         conda list
 
     # Install Julia

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,9 +40,4 @@ jobs:
     # Run lesson notebooks
     - name: Test notebook 00
       shell: bash -l {0}
-      run: |
-        ls
-        jupyter nbconvert --to notebook --inplace --execute "./lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb"
-    # - name: Test notebook 01
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb
+      run: ls

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    timeout-minutes: 20
+
     strategy:
       matrix:
         platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
@@ -27,13 +29,18 @@ jobs:
         miniconda-version: 'latest'
 
     - name: Setup Jupyter
-      run: conda install -c conda-forge notebook
+      shell: bash -l {0}
+      run: |
+        conda install -c conda-forge jupyterlab
+        conda install -c conda-forge notebook
 
     - name: Setup IJulia
       run: julia -e 'using Pkg; Pkg.add("IJulia")'
 
     # Run lesson notebooks
     - name: Test notebook 00
+      shell: bash -l {0}
       run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
     - name: Test notebook 01
+      shell: bash -l {0}
       run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,7 +34,10 @@ jobs:
         conda install -c anaconda jupyter
         conda install -c conda-forge matplotlib
         conda install -c anaconda graphviz
+        conda install -c anaconda python-graphviz 
         conda list
+        !set PATH=PATH;C:\Users\runneradmin\Library\bin\graphviz\
+        dot
 
     # Install Julia
     - name: Setup Julia environment

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,13 +26,9 @@ jobs:
       uses: goanpeca/setup-miniconda@v1.0.2
       with:
         miniconda-version: 'latest'
-        activate-environment: bmlip-env
-        environment-file: environment.yml
         python-version: 3.7
     - shell: bash -l {0}
-      run: |
-        conda info
-        conda list
+      run: conda list
 
     # Install Jupyter
     - name: Setup Jupyter

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,8 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
-        platform: [windows-latest]
+        platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -47,7 +46,10 @@ jobs:
 
     # Add IJulia kernel to Jupyter
     - name: Install IJulia kernel
-      run: julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaLang/IJulia.jl.git")); using IJulia; installkernel("julia")'
+      run: |
+        git clone https://github.com/JuliaLang/IJulia.jl.git IJulia
+        cd IJulia
+        julia -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.status(); using IJulia; installkernel("julia")'
 
     # # Run lesson notebooks
     # - name: Test notebook 00

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,13 +35,12 @@ jobs:
         conda install -c conda-forge notebook
 
     - name: Setup IJulia
-      run: julia -e 'using Pkg; Pkg.add("IJulia")'
+      run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
     - name: Test notebook 00
       shell: bash -l {0}
       run: |
-        pwd
         ls
         jupyter nbconvert --to notebook --inplace --execute "./lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb"
     # - name: Test notebook 01

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,8 +18,8 @@ jobs:
     # Clone repo
     - name: Checkout BMLIP repo
       uses: actions/checkout@v2
-        with:
-          ref: master
+      with:
+        ref: master
 
     # Install Miniconda environment
     - name: Setup Miniconda
@@ -61,6 +61,7 @@ jobs:
 
     # Run lesson notebooks
     - name: Test notebook 00
+      shell: bash -l {0}
       run: |
         cd BMLIP/lessons/notebooks
         jupyter nbconvert --to notebook --inplace --execute 00-Course-Outline-and-Admin-Issues.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,7 +40,10 @@ jobs:
     # Run lesson notebooks
     - name: Test notebook 00
       shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
-    - name: Test notebook 01
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb
+      run: |
+        pwd
+        ls
+        jupyter nbconvert --to notebook --inplace --execute "./lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb"
+    # - name: Test notebook 01
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute lessons/notebooks/01-Machine-Learning-Overview.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,27 +14,27 @@ jobs:
 
     steps:
 
-    # # Clone repo
-    # - name: Checkout BMLIP repo
-    #   uses: actions/checkout@v2
-    #   with:
-    #     ref: master
-    #
-    # # Setup Miniconda environment
-    # - name: Setup Miniconda
-    #   uses: goanpeca/setup-miniconda@v1.0.2
-    #   with:
-    #     miniconda-version: 'latest'
-    #     python-version: 3.7
-    #
-    # # Install Python dependencies
-    # - name: Install Python dependencies
-    #   shell: bash -l {0}
-    #   run: |
-    #     conda install -c anaconda jupyter
-    #     conda install -c conda-forge matplotlib
-    #     conda install -c anaconda graphviz
-    #     conda list
+    # Clone repo
+    - name: Checkout BMLIP repo
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    # Setup Miniconda environment
+    - name: Setup Miniconda
+      uses: goanpeca/setup-miniconda@v1.0.2
+      with:
+        miniconda-version: 'latest'
+        python-version: 3.7
+
+    # Install Python dependencies
+    - name: Install Python dependencies
+      shell: bash -l {0}
+      run: |
+        conda install -c anaconda jupyter
+        conda install -c conda-forge matplotlib
+        conda install -c anaconda graphviz
+        conda list
 
     # Install Julia
     - name: Setup Julia environment
@@ -49,58 +49,58 @@ jobs:
       shell: bash -l {0}
       run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
 
-    # # Run lesson notebooks
-    # - name: Test notebook 00
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
-    #
-    # - name: Test notebook 01
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
-    #
-    # - name: Test notebook 02
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
-    #
-    # - name: Test notebook 03
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
-    #
-    # - name: Test notebook 04
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
-    #
-    # - name: Test notebook 05
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
-    #
-    # - name: Test notebook 06
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
-    #
-    # - name: Test notebook 07
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
-    #
-    # - name: Test notebook 08
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
-    #
-    # - name: Test notebook 09
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
-    #
-    # - name: Test notebook 10
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
-    #
-    # - name: Test notebook 11
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/11-Dynamic-Models.ipynb
-    #
-    # - name: Test notebook 12
-    #   shell: bash -l {0}
-    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
+    # Run lesson notebooks
+    - name: Test notebook 00
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+
+    - name: Test notebook 01
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
+
+    - name: Test notebook 02
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
+
+    - name: Test notebook 03
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+
+    - name: Test notebook 04
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+
+    - name: Test notebook 05
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+
+    - name: Test notebook 06
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
+
+    - name: Test notebook 07
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
+
+    - name: Test notebook 08
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
+
+    - name: Test notebook 09
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
+
+    - name: Test notebook 10
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
+
+    - name: Test notebook 11
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/11-Dynamic-Models.ipynb
+
+    - name: Test notebook 12
+      shell: bash -l {0}
+      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
 
     # - name: Test notebook PP-1-variational
     #   shell: bash -l {0}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,15 +29,15 @@ jobs:
         miniconda-version: 'latest'
 
     - name: Setup Jupyter
-      shell: bash -l {0}
       run: |
         conda install -c conda-forge jupyterlab
         conda install -c conda-forge notebook
+        conda info
+        conda list
 
     - name: Setup IJulia
-      run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
+      run: julia -e 'using Pkg; Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
     - name: Test notebook 00
-      shell: bash -l {0}
-      run: ls
+      run: ls -a

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,15 +37,7 @@ jobs:
     # Install Jupyter
     - name: Setup Jupyter
       shell: bash -l {0}
-      run: |
-      #  conda list
-        # conda create -n bmlip python=3.7 anaconda
-        conda install -c anaconda jupyter
-      #  conda activate bmlip
-      #  conda install -c anaconda jupyter
-      #  conda install -c conda-forge notebook
-      #  conda install -c conda-forge jupyterlab
-      #  conda list
+      run: conda install -c anaconda jupyter
 
     # Install Julia
     - name: Setup Julia environment

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,26 +9,23 @@ jobs:
         platform: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}
-    
+
     steps:
-      
-    # Install Julia    
+
+    # Install Julia
     - name: Setup Julia environment
       uses: julia-actions/setup-julia@v1.1.0
       with:
         version: 1.3
         arch: x64
         show-versioninfo: true
-    
+
     # Install Jupyter with Julia kernel
     - name: Setup Miniconda
       uses: goanpeca/setup-miniconda@v1.0.2
-      with:
-        python-version: 3.x
+
     - name: Setup Jupyter
       run: conda install -c conda-forge notebook
+
     - name: Setup IJulia
       run: julia -e 'using Pkg; Pkg.add("IJulia")'
-  
-
-

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,10 +32,18 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install -c anaconda jupyter
-        conda install -c conda-forge matplotlib
+        conda install -c conda-giforge matplotlib
         conda install -c anaconda graphviz
-        conda install -c anaconda python-graphviz
-        dot -V
+        conda install pip
+        pip install graphviz
+
+    # Install GraphViz
+    - name: Setup GraphViz
+      uses: kamiazya/setup-graphviz@v1
+
+    - name: test dot
+      shell: bash -l {0}
+      run: dot -V
 
     # Install Julia
     - name: Setup Julia environment
@@ -51,49 +59,49 @@ jobs:
       run: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
-    - name: Test notebook 00
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
-
-    - name: Test notebook 01
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
-
-    - name: Test notebook 02
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
-
-    - name: Test notebook 03
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
-
-    - name: Test notebook 04
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
-
-    - name: Test notebook 05
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
-
-    - name: Test notebook 06
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
-
-    - name: Test notebook 07
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
-
-    - name: Test notebook 08
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
-
-    - name: Test notebook 09
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
-
-    - name: Test notebook 10
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
+    # - name: Test notebook 00
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+    #
+    # - name: Test notebook 01
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
+    #
+    # - name: Test notebook 02
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
+    #
+    # - name: Test notebook 03
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+    #
+    # - name: Test notebook 04
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+    #
+    # - name: Test notebook 05
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+    #
+    # - name: Test notebook 06
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
+    #
+    # - name: Test notebook 07
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
+    #
+    # - name: Test notebook 08
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
+    #
+    # - name: Test notebook 09
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
+    #
+    # - name: Test notebook 10
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
 
     - name: Test notebook 11
       shell: bash -l {0}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,10 +34,8 @@ jobs:
         conda install -c anaconda jupyter
         conda install -c conda-forge matplotlib
         conda install -c anaconda graphviz
-        conda install -c anaconda python-graphviz 
-        conda list
-        !set PATH=PATH;C:\Users\runneradmin\Library\bin\graphviz\
-        dot
+        conda install -c anaconda python-graphviz
+        dot -V
 
     # Install Julia
     - name: Setup Julia environment

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,34 @@
+name: test-build
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+      
+    # Install Julia    
+    - name: Setup Julia environment
+      uses: julia-actions/setup-julia@v1.1.0
+      with:
+        version: 1.3
+        arch: x64
+        show-versioninfo: true
+    
+    # Install Jupyter with Julia kernel
+    - name: Setup Miniconda
+      uses: goanpeca/setup-miniconda@v1.0.2
+      with:
+        python-version: 3.x
+    - name: Setup Jupyter
+      run: conda install -c conda-forge notebook
+    - name: Setup IJulia
+      run: julia -e 'using Pkg; Pkg.add("IJulia")'
+  
+
+

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
+        # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
+        platform: [windows-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -46,7 +47,7 @@ jobs:
 
     # Add IJulia kernel to Jupyter
     - name: Install IJulia kernel
-      run: julia -e 'using Pkg; Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
+      run: julia -e 'using Pkg; Pkg.instantiate(); Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
 
     # Run lesson notebooks
     - name: Test notebook 00

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         miniconda-version: 'latest'
         activate-environment: bmlip-env
-        environment-file: BMLIP/environment.yml
+        environment-file: environment.yml
         python-version: 3.7
     - shell: bash -l {0}
       run: |
@@ -55,5 +55,5 @@ jobs:
     - name: Test notebook 00
       shell: bash -l {0}
       run: |
-        cd BMLIP/lessons/notebooks
+        cd lessons/notebooks
         jupyter nbconvert --to notebook --inplace --execute 00-Course-Outline-and-Admin-Issues.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,8 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        # platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
-        platform: [ubuntu-latest, ubuntu-18.04, macos-latest]
+        platform: [windows-latest, ubuntu-latest, ubuntu-18.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -34,7 +33,7 @@ jobs:
       run: |
         conda install -c anaconda jupyter
         conda install -c conda-forge matplotlib
-        conda install -c anaconda graphviz 
+        conda install -c anaconda graphviz
         conda list
 
     # Install Julia

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,9 +30,9 @@ jobs:
 
     - name: Setup Jupyter
       run: |
-        conda install -c conda-forge jupyterlab
-        conda install -c conda-forge notebook
         conda update -n base -c defaults conda
+        conda install -c conda-forge notebook
+        conda install -c conda-forge jupyterlab
         conda info
         conda list
 
@@ -43,10 +43,9 @@ jobs:
     - name: Clone BMLIP repo
       run: |
         git clone https://github.com/bertdv/BMLIP.git
-        cd BMLIP
+        cd BMLIP/lessons/notebooks
 
     # Run lesson notebooks
     - name: Test notebook 00
       run: |
-        ls -a
-        jupyter nbconvert --to notebook --inplace --execute "./lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb"
+        jupyter nbconvert --to notebook --inplace --execute 00-Course-Outline-and-Admin-Issues.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,6 +15,38 @@ jobs:
 
     steps:
 
+    # Clone repo
+    - name: Checkout BMLIP repo
+      uses: actions/checkout@v2
+        with:
+          ref: master
+
+    # Install Miniconda environment
+    - name: Setup Miniconda
+      uses: goanpeca/setup-miniconda@v1.0.2
+      with:
+        miniconda-version: 'latest'
+        activate-environment: bmlip-env
+        environment-file: BMLIP/.github/workflows/environment.yml
+        python-version: 3.7
+    - shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+
+    # Install Jupyter
+    - name: Setup Jupyter
+      shell: bash -l {0}
+      run: |
+      #  conda list
+        # conda create -n bmlip python=3.7 anaconda
+        conda install -c anaconda jupyter
+      #  conda activate bmlip
+      #  conda install -c anaconda jupyter
+      #  conda install -c conda-forge notebook
+      #  conda install -c conda-forge jupyterlab
+      #  conda list
+
     # Install Julia
     - name: Setup Julia environment
       uses: julia-actions/setup-julia@v1.1.0
@@ -23,33 +55,12 @@ jobs:
         arch: x64
         show-versioninfo: true
 
-    # Install Jupyter with Julia kernel
-    - name: Setup Miniconda
-      uses: goanpeca/setup-miniconda@v1.0.2
-      with:
-        miniconda-version: 'latest'
-
-    - name: Setup Jupyter
-      run: |
-        conda update conda
-        conda create -n bmlip python=3.7 anaconda
-        conda activate bmlip
-        conda list
-        conda install -c anaconda jupyter
-        conda install -c conda-forge notebook
-        conda install -c conda-forge jupyterlab
-        conda list
-
+    # Add IJulia kernel to Jupyter
     - name: Setup IJulia
       run: julia -e 'using Pkg; Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
-
-    # Clone repo
-    - name: Clone BMLIP repo
-      run: |
-        git clone https://github.com/bertdv/BMLIP.git
-        cd BMLIP/lessons/notebooks
 
     # Run lesson notebooks
     - name: Test notebook 00
       run: |
+        cd BMLIP/lessons/notebooks
         jupyter nbconvert --to notebook --inplace --execute 00-Course-Outline-and-Admin-Issues.ipynb

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,27 +15,27 @@ jobs:
 
     steps:
 
-    # Clone repo
-    - name: Checkout BMLIP repo
-      uses: actions/checkout@v2
-      with:
-        ref: master
-
-    # Setup Miniconda environment
-    - name: Setup Miniconda
-      uses: goanpeca/setup-miniconda@v1.0.2
-      with:
-        miniconda-version: 'latest'
-        python-version: 3.7
-
-    # Install Python dependencies
-    - name: Install Python dependencies
-      shell: bash -l {0}
-      run: |
-        conda install -c anaconda jupyter
-        conda install -c conda-forge matplotlib
-        conda install -c anaconda graphviz
-        conda list
+    # # Clone repo
+    # - name: Checkout BMLIP repo
+    #   uses: actions/checkout@v2
+    #   with:
+    #     ref: master
+    #
+    # # Setup Miniconda environment
+    # - name: Setup Miniconda
+    #   uses: goanpeca/setup-miniconda@v1.0.2
+    #   with:
+    #     miniconda-version: 'latest'
+    #     python-version: 3.7
+    #
+    # # Install Python dependencies
+    # - name: Install Python dependencies
+    #   shell: bash -l {0}
+    #   run: |
+    #     conda install -c anaconda jupyter
+    #     conda install -c conda-forge matplotlib
+    #     conda install -c anaconda graphviz
+    #     conda list
 
     # Install Julia
     - name: Setup Julia environment
@@ -47,60 +47,62 @@ jobs:
 
     # Add IJulia kernel to Jupyter
     - name: Install IJulia kernel
-      run: julia -e 'using Pkg; Pkg.instantiate(); Pkg.add("IJulia"); Pkg.status(); using IJulia; installkernel("julia")'
+      run: |
+        pwd
+        julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaLang/IJulia.jl.git")); using IJulia; installkernel("julia")'
 
-    # Run lesson notebooks
-    - name: Test notebook 00
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
-
-    - name: Test notebook 01
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
-
-    - name: Test notebook 02
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
-
-    - name: Test notebook 03
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
-
-    - name: Test notebook 04
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
-
-    - name: Test notebook 05
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
-
-    - name: Test notebook 06
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
-
-    - name: Test notebook 07
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
-
-    - name: Test notebook 08
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
-
-    - name: Test notebook 09
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
-
-    - name: Test notebook 10
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
-
-    - name: Test notebook 11
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/11-Dynamic-Models.ipynb
-
-    - name: Test notebook 12
-      shell: bash -l {0}
-      run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
+    # # Run lesson notebooks
+    # - name: Test notebook 00
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/00-Course-Outline-and-Admin-Issues.ipynb
+    #
+    # - name: Test notebook 01
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/01-Machine-Learning-Overview.ipynb
+    #
+    # - name: Test notebook 02
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/02-Probability-Theory-Review.ipynb
+    #
+    # - name: Test notebook 03
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/03-Bayesian-Machine-Learning.ipynb
+    #
+    # - name: Test notebook 04
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/04-The-Gaussian-Distribution.ipynb
+    #
+    # - name: Test notebook 05
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/05-The-Multinomial-Distribution.ipynb
+    #
+    # - name: Test notebook 06
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/06-Regression.ipynb
+    #
+    # - name: Test notebook 07
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/07-Generative-Classification.ipynb
+    #
+    # - name: Test notebook 08
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/08-Discriminative-Classification.ipynb
+    #
+    # - name: Test notebook 09
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/09-Latent-Variable-Models-and-VB.ipynb
+    #
+    # - name: Test notebook 10
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/10-Factor-Graphs.ipynb
+    #
+    # - name: Test notebook 11
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/11-Dynamic-Models.ipynb
+    #
+    # - name: Test notebook 12
+    #   shell: bash -l {0}
+    #   run: jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=-1 lessons/notebooks/12-Intelligent-Agents-and-Active-Inference.ipynb
 
     # - name: Test notebook PP-1-variational
     #   shell: bash -l {0}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,13 +27,12 @@ jobs:
       uses: goanpeca/setup-miniconda@v1.0.2
       with:
         miniconda-version: 'latest'
+
+    - name: Setup Jupyter
       run: |
         conda update conda
         conda create -n bmlip python=3.7 anaconda
         source activate bmlip
-
-    - name: Setup Jupyter
-      run: |
         conda list
         conda install -c anaconda jupyter
         conda install -c conda-forge notebook

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"

--- a/environment.yml
+++ b/environment.yml
@@ -1,2 +1,3 @@
 dependencies:
   - matplotlib
+  - jupyter


### PR DESCRIPTION
I started a branch to develop the build script for GH Actions. It took me a while because GH Actions differs from Travis. 

It currently tests the 12 lectures by Bert on Windows, Ubuntu and MacOS. The plan is to add the Probabilistic Programming notebooks as well, but these can't be tested in the same way. They contain assignments with missing code, which triggers errors.