### PR TITLE
Fix RxInfer version

### DIFF
--- a/lessons/Project.toml
+++ b/lessons/Project.toml
@@ -26,4 +26,4 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 
 [compat]
-RxInfer = "2.13"
+RxInfer = "~2.13"


### PR DESCRIPTION
I thought I fixed the RxInfer version before, but apparently I didn't. This is to avoid confusion and unnecessary warnings thrown by new rxinfer versions as discussed in rxinfer meeting.